### PR TITLE
Alert added

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This is an extension pack of the following VS Code markdown preview extensions. 
 
 - [Markdown Mermaid](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid&ssr=false#review-details) - Adds Mermaid diagram and flowchart support to VS Code's builtin markdown preview.
 
+- [Markdown Alert](https://marketplace.visualstudio.com/items?itemName=yahyabatulu.vscode-markdown-alert&ssr=false#review-details) - Adds `[!INFO]` alert syntax support to VS Code's builtin markdown preview.
+
 # Usage
 
 Please see the [VSCode Markdown Preview documentation](https://code.visualstudio.com/Docs/languages/markdown#_markdown-preview)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bierner.markdown-checkbox",
     "bierner.markdown-yaml-preamble",
     "bierner.markdown-footnotes",
-    "bierner.markdown-mermaid"
+    "bierner.markdown-mermaid",
+    "yahyabatulu.vscode-markdown-alert"
   ]
 }


### PR DESCRIPTION
> [!NOTE]
> Following syntax is not available with the VS Code's built-in markdown preview.
```
> [!NOTE]
> Following syntax is not available with the VS Code's built-in markdown preview.
```

Thought it would be good to have this extension of mine in this package.